### PR TITLE
give icons in modulbuilding a title

### DIFF
--- a/src/html/colonymacros.xhtml
+++ b/src/html/colonymacros.xhtml
@@ -752,7 +752,7 @@
             </div>
             <tal:block tal:repeat="cost data/getConstructionCosts">
               <div style="display: table-cell; padding-left: 4px;">
-                <img src="assets/goods/${cost/getCommodity/getId}.gif" />
+                <img src="assets/goods/${cost/getCommodity/getId}.gif" tal:attributes="title cost/getCommodity/getName"/>
               </div>
               <div style="display: table-cell; vertical-align: middle;" tal:content="cost/getAmount">COST</div>
             </tal:block>


### PR DESCRIPTION
Hiermit sollte im Modulbaumenü der Name des Icons angezeigt werden, wenn man mit der Maus drüber geht