### PR TITLE
Load session handler only if session has been started

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -496,11 +496,6 @@ parameters:
 			path: src/Component/Station/StationUtility.php
 
 		-
-			message: "#^Variable \\$container might not be defined\\.$#"
-			count: 2
-			path: src/Config/ErrorHandler.php
-
-		-
 			message: "#^Method Stu\\\\Exception\\\\SanityCheckException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
 			count: 1
 			path: src/Exception/SanityCheckException.php

--- a/src/Lib/Session.php
+++ b/src/Lib/Session.php
@@ -72,7 +72,7 @@ final class Session implements SessionInterface
     public function checkLoginCookie(): void
     {
         $sstr = $_COOKIE['sstr'] ?? '';
-        $uid = intval($_SESSION['uid']);
+        $uid = intval($_SESSION['uid'] ?? 0);
         if ($uid > 0) {
             $this->performCookieLogin($uid, $sstr);
         }


### PR DESCRIPTION
The error handler checks for the existence of a currently logged-in user. This may cause trouble, especially in cli-envs. So, load the session handler only iof a session has been started beforehand.