### PR TITLE
Add cli script for local user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ composer, git.
 - make dev-create-db
 - php src/admin/scripts/reset.php
 - make dev-serve
+- Use the cli command to create a new user `./bin/cli user:create--help`
 
 Danach sollte die Software via http://localhost:1337 erreichbar sein, ggf. kann
 es sein, dass der Hostname (stu-db) nicht aufgelöst werden kann. In diesem

--- a/bin/cli
+++ b/bin/cli
@@ -3,29 +3,44 @@
 declare(strict_types=1);
 
 use Ahc\Cli\IO\Interactor;
+use Doctrine\ORM\EntityManagerInterface;
 use Noodlehaus\ConfigInterface;
 use Psr\Container\ContainerInterface;
+use Stu\Component\Cli\UserCreateCommand;
 use Stu\Config\Init;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 Init::run(
     function (ContainerInterface $dic): void {
+        $em = $dic->get(EntityManagerInterface::class);
+
+        $em->beginTransaction();
+
         $app = new Ahc\Cli\Application(
             'Star Trek Universe CLI',
-            $dic->get(ConfigInterface::class)->get('game.version')
+            $dic->get(ConfigInterface::class)->get('game.version'),
+            function (int $exitCode = 0) use ($em): void {
+                if ($exitCode === 0) {
+                    $em->commit();
+                } else {
+                    $em->rollback();
+                }
+                exit($exitCode);
+            }
         );
         $app->io(new Interactor());
 
         $logo = <<<LOGO
-          .dBBBBP  dBBBBBBP dBP dBP    dBBBP  dBP    dBP
-          BP
-          `BBBBb    dBP   dBP dBP    dBP    dBP    dBP
-             dBP   dBP   dBP_dBP    dBP    dBP    dBP
-        dBBBBP'   dBP   dBBBBBP    dBBBBP dBBBBP dBP
-        LOGO;
+              .dBBBBP  dBBBBBBP dBP dBP    dBBBP  dBP    dBP
+              BP
+              `BBBBb    dBP   dBP dBP    dBP    dBP    dBP
+                 dBP   dBP   dBP_dBP    dBP    dBP    dBP
+            dBBBBP'   dBP   dBBBBBP    dBBBBP dBBBBP dBP
+            LOGO;
 
         $app->logo($logo);
+        $app->add(new UserCreateCommand($dic));
 
         $app->handle($_SERVER['argv']);
     }

--- a/src/Component/Cli/UserCreateCommand.php
+++ b/src/Component/Cli/UserCreateCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu\Component\Cli;
+
+use Ahc\Cli\Input\Command;
+use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
+use Stu\Component\Faction\FactionEnum;
+use Stu\Component\Player\Register\LocalPlayerCreator;
+use Stu\Module\PlayerSetting\Action\ChangePassword\ChangePassword;
+use Stu\Orm\Entity\FactionInterface;
+use Stu\Orm\Repository\FactionRepositoryInterface;
+
+/**
+ * Provides cli method for user creation
+ */
+final class UserCreateCommand extends Command
+{
+    private ContainerInterface $dic;
+
+    public function __construct(
+        ContainerInterface $dic
+    ) {
+        $this->dic = $dic;
+
+        parent::__construct(
+            'user:create',
+            'Creates a new user'
+        );
+
+        $this
+            ->argument(
+                '<username>',
+                'Login name'
+            )
+            ->argument(
+                '<email>',
+                'Email-address'
+            )
+            ->argument(
+                '<faction>',
+                'Name of the faction the user should belong to'
+            )
+            ->usage(
+                '<bold>  $0 user:create foobar foobar@example.com klingon</end> <comment></end> ## Creates a new klingon player<eol/>'
+            );
+    }
+
+    public function execute(string $username, string $email, string $faction): void
+    {
+        $io = $this->io();
+
+        $passValidator = function (string $password): string {
+            if (!preg_match(ChangePassword::PASSWORD_REGEX, $password)) {
+                throw new InvalidArgumentException('Password does not meet requirements (6-20 alphanumerical characters)');
+            }
+
+            return $password;
+        };
+
+        // perform some validation
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidArgumentException('The provided email address is invalid');
+        }
+
+        $factionId = FactionEnum::FACTION_NAME_TO_ID_MAP[$faction] ?? null;
+        if ($factionId === null) {
+            throw new InvalidArgumentException('The provided faction is invalid');
+        }
+
+        // prompt for the password
+        $password = $io->promptHidden('Password', $passValidator, 2);
+
+        /** @var FactionInterface $faction */
+        $faction = $this->dic->get(FactionRepositoryInterface::class)->find($factionId);
+
+        $player = $this->dic->get(LocalPlayerCreator::class)->createPlayer(
+            $username,
+            $email,
+            $faction,
+            $password
+        );
+
+        $io->ok(
+            sprintf(
+                'Player with ID %s has been created',
+                $player->getId()
+            ),
+            true
+        );
+    }
+}

--- a/src/Component/Cli/services.php
+++ b/src/Component/Cli/services.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu\Module\Cli;
+
+use Stu\Component\Cli\UserCreateCommand;
+use Stu\Component\Player\Register\LocalPlayerCreator;
+use function DI\autowire;
+use function DI\get;
+
+return [
+    UserCreateCommand::class => autowire()
+        ->constructorParameter(
+            'playerCreator',
+            get(LocalPlayerCreator::class)
+        )
+];

--- a/src/Component/Faction/FactionEnum.php
+++ b/src/Component/Faction/FactionEnum.php
@@ -6,6 +6,14 @@ namespace Stu\Component\Faction;
 
 final class FactionEnum
 {
+    /** @var array<string, int> */
+    public const FACTION_NAME_TO_ID_MAP = [
+        'federation' => self::FACTION_FEDERATION,
+        'romulan' => self::FACTION_ROMULAN,
+        'klingon' => self::FACTION_KLINGON,
+        'cardassian' => self::FACTION_CARDASSIAN,
+        'ferengi' => self::FACTION_FERENGI,
+    ];
 
     public const FACTION_FEDERATION = 1;
     public const FACTION_ROMULAN = 2;

--- a/src/Component/Player/Register/LocalPlayerCreator.php
+++ b/src/Component/Player/Register/LocalPlayerCreator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu\Component\Player\Register;
+
+use Stu\Orm\Entity\FactionInterface;
+use Stu\Orm\Entity\UserInterface;
+
+/**
+ * Creates players without any registration/validation
+ */
+final class LocalPlayerCreator extends PlayerCreator
+{
+    public function createPlayer(
+        string $loginName,
+        string $emailAddress,
+        FactionInterface $faction,
+        string $password,
+        string $mobile = null,
+        string $smsCode = null
+    ): UserInterface {
+        $player = $this->userRepository->prototype();
+        $player->setLogin($loginName);
+        $player->setEmail($emailAddress);
+        $player->setFaction($faction);
+
+        $this->userRepository->save($player);
+
+        $player->setUsername(sprintf('Siedler %d', $player->getId()));
+        $player->setTick(1);
+        $player->setCreationDate(time());
+        $player->setPassword((string) password_hash($password, PASSWORD_DEFAULT));
+
+        $this->userRepository->save($player);
+
+        $this->playerDefaultsCreator->createDefault($player);
+
+        return $player;
+    }
+}

--- a/src/Component/Player/Register/PlayerCreator.php
+++ b/src/Component/Player/Register/PlayerCreator.php
@@ -18,11 +18,14 @@ use Stu\Orm\Entity\UserInterface;
 use Stu\Orm\Repository\UserInvitationRepositoryInterface;
 use Stu\Orm\Repository\UserRepositoryInterface;
 
-final class PlayerCreator implements PlayerCreatorInterface
+/**
+ * Creates players with registration and optional sms validation
+ */
+class PlayerCreator implements PlayerCreatorInterface
 {
-    private UserRepositoryInterface $userRepository;
+    protected UserRepositoryInterface $userRepository;
 
-    private PlayerDefaultsCreatorInterface $playerDefaultsCreator;
+    protected PlayerDefaultsCreatorInterface $playerDefaultsCreator;
 
     private RegistrationEmailSenderInterface $registrationEmailSender;
 
@@ -73,7 +76,8 @@ final class PlayerCreator implements PlayerCreatorInterface
         $player = $this->createPlayer(
             $loginName,
             $emailAddress,
-            $faction
+            $faction,
+            $this->passwordGenerator->generatePassword()
         );
 
         $invitation->setInvitedUserId($player->getId());
@@ -96,6 +100,7 @@ final class PlayerCreator implements PlayerCreatorInterface
             $loginName,
             $emailAddress,
             $faction,
+            $this->passwordGenerator->generatePassword(),
             $mobileWithDoubleZero,
             $randomHash
         );
@@ -141,6 +146,7 @@ final class PlayerCreator implements PlayerCreatorInterface
         string $loginName,
         string $emailAddress,
         FactionInterface $faction,
+        string $password,
         string $mobile = null,
         string $smsCode = null
     ): UserInterface {
@@ -150,8 +156,6 @@ final class PlayerCreator implements PlayerCreatorInterface
         $player->setFaction($faction);
 
         $this->userRepository->save($player);
-
-        $password = $this->passwordGenerator->generatePassword();
 
         $player->setUsername('Siedler ' . $player->getId());
         $player->setTick(1);

--- a/src/Component/Player/Register/PlayerCreatorInterface.php
+++ b/src/Component/Player/Register/PlayerCreatorInterface.php
@@ -31,6 +31,9 @@ interface PlayerCreatorInterface
     public function createPlayer(
         string $loginName,
         string $emailAddress,
-        FactionInterface $faction
+        FactionInterface $faction,
+        string $password,
+        string $mobile = null,
+        string $smsCode = null
     ): UserInterface;
 }

--- a/src/Component/Player/services.php
+++ b/src/Component/Player/services.php
@@ -18,6 +18,7 @@ use Stu\Component\Player\Deletion\PlayerDeletion;
 use Stu\Component\Player\Deletion\PlayerDeletionInterface;
 use Stu\Component\Player\Invitation\InvitePlayer;
 use Stu\Component\Player\Invitation\InvitePlayerInterface;
+use Stu\Component\Player\Register\LocalPlayerCreator;
 use Stu\Component\Player\Register\PlayerCreator;
 use Stu\Component\Player\Register\PlayerCreatorInterface;
 use Stu\Component\Player\Register\RegistrationEmailSender;
@@ -63,6 +64,7 @@ return [
     LoginValidationInterface::class => create(LoginValidation::class)->constructor([
         autowire(IpIntelValidator::class)
     ]),
+    LocalPlayerCreator::class => autowire(),
     PlayerCreatorInterface::class => autowire(PlayerCreator::class),
     PlayerDefaultsCreatorInterface::class => autowire(PlayerDefaultsCreator::class),
     RegistrationEmailSenderInterface::class => autowire(RegistrationEmailSender::class),

--- a/src/Config/Bootstrap.php
+++ b/src/Config/Bootstrap.php
@@ -52,6 +52,7 @@ $builder->addDefinitions(__DIR__ . '/../Component/Specials/services.php');
 $builder->addDefinitions(__DIR__ . '/../Module/Tick/services.php');
 $builder->addDefinitions(__DIR__ . '/../Orm/Repository/services.php',);
 $builder->addDefinitions(__DIR__ . '/../Module/Maintenance/services.php');
+$builder->addDefinitions(__DIR__ . '/../Component/Cli/services.php');
 
 /** @var ContainerInterface $container */
 $container = $builder->build();

--- a/src/Config/Init.php
+++ b/src/Config/Init.php
@@ -55,6 +55,7 @@ final class Init
         $builder->addDefinitions(__DIR__ . '/../Module/Tick/services.php');
         $builder->addDefinitions(__DIR__ . '/../Orm/Repository/services.php',);
         $builder->addDefinitions(__DIR__ . '/../Module/Maintenance/services.php');
+        $builder->addDefinitions(__DIR__ . '/../Component/Cli/services.php');
 
         /** @var ContainerInterface $container */
         $container = $builder->build();

--- a/src/Module/PlayerSetting/Action/ChangePassword/ChangePassword.php
+++ b/src/Module/PlayerSetting/Action/ChangePassword/ChangePassword.php
@@ -12,6 +12,11 @@ final class ChangePassword implements ActionControllerInterface
 {
     public const ACTION_IDENTIFIER = 'B_CHANGE_PASSWORD';
 
+    /**
+     * @todo Extract into a separate password validator
+     */
+    public const PASSWORD_REGEX = '/[a-zA-Z0-9]{6,20}/';
+
     private ChangePasswordRequestInterface $changePasswordRequest;
 
     private UserRepositoryInterface $userRepository;
@@ -45,7 +50,7 @@ final class ChangePassword implements ActionControllerInterface
             $game->addInformation(_('Es wurde kein neues Passwort eingegeben'));
             return;
         }
-        if (!preg_match('/[a-zA-Z0-9]{6,20}/', $newPassword)) {
+        if (!preg_match(self::PASSWORD_REGEX, $newPassword)) {
             $game->addInformation(_('Das Passwort darf nur aus Zahlen und Buchstaben bestehen und muss zwischen 6 und 20 Zeichen lang sein'));
             return;
         }

--- a/src/Orm/Repository/PrivateMessageFolderRepository.php
+++ b/src/Orm/Repository/PrivateMessageFolderRepository.php
@@ -24,6 +24,7 @@ final class PrivateMessageFolderRepository extends EntityRepository implements P
         $em = $this->getEntityManager();
 
         $em->persist($post);
+        $em->flush();
     }
 
     public function delete(PrivateMessageFolderInterface $post): void

--- a/src/Orm/Repository/ResearchedRepository.php
+++ b/src/Orm/Repository/ResearchedRepository.php
@@ -80,6 +80,7 @@ final class ResearchedRepository extends EntityRepository implements ResearchedR
         $em = $this->getEntityManager();
 
         $em->persist($researched);
+        $em->flush();
     }
 
     public function delete(ResearchedInterface $researched): void

--- a/src/admin/scripts/reset.php
+++ b/src/admin/scripts/reset.php
@@ -33,10 +33,4 @@ $entityManager->getConnection()->query(
     )
 );
 
-$playerCreator->createPlayer(
-    $config->get('game.admin.username'),
-    $config->get('game.admin.email'),
-    $factionRepo->find($config->get('game.admin.faction'))
-);
-
 $entityManager->commit();

--- a/tests/CliInteractorHelper.php
+++ b/tests/CliInteractorHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu;
+use Ahc\Cli\IO\Interactor;
+use Ahc\Cli\Output\Writer;
+
+class CliInteractorHelper extends Interactor
+{
+    public function eol($n = 1): Writer
+    {
+        return parent::eol($n);
+    }
+
+    public function error(
+        string $text,
+        bool $eol = false
+    ): Writer {
+        return parent::error(
+            $text,
+            $eol
+        );
+    }
+
+    public function ok(
+        string $text,
+        bool $eol = false
+    ): Writer {
+        return parent::error(
+            $text,
+            $eol
+        );
+    }
+
+    public function info(
+        string $text,
+        bool $eol = false
+    ): Writer {
+        return parent::info(
+            $text,
+            $eol
+        );
+    }
+
+    public function table(array $rows, array $styles = []): Writer
+    {
+        return parent::__call('table', [$rows, $styles]);
+    }
+}

--- a/tests/Component/Cli/UserCreateCommandTest.php
+++ b/tests/Component/Cli/UserCreateCommandTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu\Component\Cli;
+
+use Ahc\Cli\Application;
+use InvalidArgumentException;
+use Mockery;
+use Mockery\MockInterface;
+use Psr\Container\ContainerInterface;
+use Stu\CliInteractorHelper;
+use Stu\Component\Faction\FactionEnum;
+use Stu\Component\Player\Register\LocalPlayerCreator;
+use Stu\Component\Player\Register\PlayerCreatorInterface;
+use Stu\Orm\Entity\FactionInterface;
+use Stu\Orm\Entity\UserInterface;
+use Stu\Orm\Repository\FactionRepositoryInterface;
+use Stu\StuTestCase;
+
+class UserCreateCommandTest extends StuTestCase
+{
+    /** @var MockInterface&ContainerInterface */
+    private MockInterface $dic;
+
+    private UserCreateCommand $subject;
+
+    protected function setUp(): void
+    {
+        $this->dic = $this->mock(ContainerInterface::class);
+
+        $this->subject = new UserCreateCommand(
+            $this->dic
+        );
+    }
+
+    public function testExecuteErrorsDueToInvalidEmailAddress(): void
+    {
+        static::expectException(InvalidArgumentException::class);
+        static::expectErrorMessage('The provided email address is invalid');
+
+        $this->subject->execute(
+            'snafu',
+            'roedlbroem',
+            'some-faction'
+        );
+    }
+
+    public function testExecuteErrorsDueToUnknownFaction(): void
+    {
+        static::expectException(InvalidArgumentException::class);
+        static::expectErrorMessage('The provided faction is invalid');
+
+        $this->subject->execute(
+            'snafu',
+            'roedlbroem@example.com',
+            'some-faction'
+        );
+    }
+
+    public function testExecuteErrorsDueToInvalidPassword(): void
+    {
+        static::expectException(InvalidArgumentException::class);
+        static::expectErrorMessage('Password does not meet requirements (6-20 alphanumerical characters)');
+
+        $app = $this->mock(Application::class);
+        $interactor = $this->mock(CliInteractorHelper::class);
+
+        $userName = 'some-username';
+        $emailAddress = 'some@example.com';
+        $password = 'ö';
+
+        $this->subject->bind($app);
+
+        $app->shouldReceive('io')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($interactor);
+
+        $interactor->shouldReceive('promptHidden')
+            ->with(
+                'Password',
+                Mockery::on(function (callable $validator) use ($password): bool {
+                    $validator($password);
+
+                    return false;
+                }),
+                2
+            );
+
+        $this->subject->execute(
+            $userName,
+            $emailAddress,
+            'klingon'
+        );
+    }
+
+    public function testExecuteErrorsDueToUnMappableFaction(): void
+    {
+        $app = $this->mock(Application::class);
+        $interactor = $this->mock(CliInteractorHelper::class);
+        $factionRepository = $this->mock(FactionRepositoryInterface::class);
+        $playerCreator = $this->mock(PlayerCreatorInterface::class);
+        $faction = $this->mock(FactionInterface::class);
+        $user = $this->mock(UserInterface::class);
+
+        $userName = 'some-username';
+        $emailAddress = 'some@example.com';
+        $password = 'somepassword';
+        $userId = 666;
+
+        $this->subject->bind($app);
+
+        $app->shouldReceive('io')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($interactor);
+
+        $interactor->shouldReceive('promptHidden')
+            ->with(
+                'Password',
+                Mockery::on(function (callable $validator) use ($password): bool {
+                    $validator($password);
+
+                    return true;
+                }),
+                2
+            )
+            ->once()
+            ->andReturn($password);
+        $interactor->shouldReceive('ok')
+            ->with(
+                sprintf(
+                    'Player with ID %s has been created',
+                    $userId
+                ),
+                true
+            )
+            ->once();
+
+        $this->dic->shouldReceive('get')
+            ->with(FactionRepositoryInterface::class)
+            ->once()
+            ->andReturn($factionRepository);
+        $this->dic->shouldReceive('get')
+            ->with(LocalPlayerCreator::class)
+            ->once()
+            ->andReturn($playerCreator);
+
+        $factionRepository->shouldReceive('find')
+            ->with(FactionEnum::FACTION_KLINGON)
+            ->once()
+            ->andReturn($faction);
+
+        $playerCreator->shouldReceive('createPlayer')
+            ->with(
+                $userName,
+                $emailAddress,
+                $faction,
+                $password
+            )
+            ->once()
+            ->andReturn($user);
+
+        $user->shouldReceive('getId')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($userId);
+
+        $this->subject->execute(
+            $userName,
+            $emailAddress,
+            'klingon'
+        );
+    }
+}

--- a/tests/Component/Player/Register/LocalPlayerCreatorTest.php
+++ b/tests/Component/Player/Register/LocalPlayerCreatorTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stu\Component\Player\Register;
+
+use Hackzilla\PasswordGenerator\Generator\PasswordGeneratorInterface;
+use Mockery;
+use Mockery\MockInterface;
+use Noodlehaus\ConfigInterface;
+use Psr\Container\ContainerInterface;
+use Stu\Module\Control\StuHashInterface;
+use Stu\Orm\Entity\FactionInterface;
+use Stu\Orm\Entity\UserInterface;
+use Stu\Orm\Repository\UserInvitationRepositoryInterface;
+use Stu\Orm\Repository\UserRepositoryInterface;
+use Stu\StuTestCase;
+
+class LocalPlayerCreatorTest extends StuTestCase
+{
+    /** @var MockInterface&UserRepositoryInterface */
+    private MockInterface $userRepository;
+
+    /** @var MockInterface&PlayerDefaultsCreatorInterface */
+    private MockInterface $playerDefaultsCreator;
+
+    /** @var MockInterface&RegistrationEmailSenderInterface */
+    private MockInterface $registrationEmailSender;
+
+    /** @var MockInterface&SmsVerificationCodeSenderInterface */
+    private MockInterface $smsVerificationCodeSender;
+
+    /** @var MockInterface&MockInterface */
+    private MockInterface $userInvitationRepository;
+
+    /** @var MockInterface&StuHashInterface */
+    private MockInterface $stuHash;
+
+    /** @var MockInterface&ConfigInterface */
+    private MockInterface $config;
+
+    /** @var MockInterface&PasswordGeneratorInterface */
+    private MockInterface $passwordGenerator;
+
+    private LocalPlayerCreator $subject;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = $this->mock(UserRepositoryInterface::class);
+        $this->playerDefaultsCreator = $this->mock(PlayerDefaultsCreatorInterface::class);
+        $this->registrationEmailSender = $this->mock(RegistrationEmailSenderInterface::class);
+        $this->smsVerificationCodeSender = $this->mock(SmsVerificationCodeSenderInterface::class);
+        $this->userInvitationRepository = $this->mock(UserInvitationRepositoryInterface::class);
+        $this->stuHash = $this->mock(StuHashInterface::class);
+        $this->config = $this->mock(ConfigInterface::class);
+        $this->passwordGenerator = $this->mock(PasswordGeneratorInterface::class);
+
+        $this->subject = new LocalPlayerCreator(
+            $this->userRepository,
+            $this->playerDefaultsCreator,
+            $this->registrationEmailSender,
+            $this->smsVerificationCodeSender,
+            $this->userInvitationRepository,
+            $this->stuHash,
+            $this->config,
+            $this->passwordGenerator
+        );
+    }
+
+    public function testCreatePlayerCreates(): void
+    {
+        $loginName = 'some-name';
+        $emailAddress = 'some-email';
+        $password = 'some-password';
+        $userId = 666;
+
+        $faction = $this->mock(FactionInterface::class);
+        $user = $this->mock(UserInterface::class);
+
+        $this->userRepository->shouldReceive('prototype')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($user);
+        $this->userRepository->shouldReceive('save')
+            ->with($user)
+            ->twice();
+
+        $user->shouldReceive('setLogin')
+            ->with($loginName)
+            ->once();
+        $user->shouldReceive('setEmail')
+            ->with($emailAddress)
+            ->once();
+        $user->shouldReceive('setFaction')
+            ->with($faction)
+            ->once();
+        $user->shouldReceive('setUsername')
+            ->with(
+                sprintf('Siedler %d', $userId)
+            )
+            ->once();
+        $user->shouldReceive('setTick')
+            ->with(1)
+            ->once();
+        $user->shouldReceive('setCreationDate')
+            ->with(Mockery::type('int'))
+            ->once();
+        $user->shouldReceive('setPassword')
+            ->with(Mockery::on(function (string $passwordHash) use ($password): bool {
+                return password_verify($password, $passwordHash);
+            }))
+            ->once();
+        $user->shouldReceive('getId')
+            ->withNoArgs()
+            ->once()
+            ->andReturn($userId);
+
+        $this->playerDefaultsCreator->shouldReceive('createDefault')
+            ->with($user)
+            ->once();
+
+        static::assertSame(
+            $user,
+            $this->subject->createPlayer(
+                $loginName,
+                $emailAddress,
+                $faction,
+                $password
+            )
+        );
+    }
+}


### PR DESCRIPTION
In order to make local dev environments work again, we need a way to create a new user after the data reset.
Currently, the PlayerCreator assigns a generated password and sends a registration-mail, unfortunately local email sending is a bit tricky - so allow users to be created via cli and allow to define a password.