### PR TITLE
Migrate entitymanager configuration

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -40,11 +40,11 @@ Init::run(
         $app->io(new Interactor());
 
         $logo = <<<LOGO
-              .dBBBBP  dBBBBBBP dBP dBP    dBBBP  dBP    dBP
-              BP
-              `BBBBb    dBP   dBP dBP    dBP    dBP    dBP
-                 dBP   dBP   dBP_dBP    dBP    dBP    dBP
-            dBBBBP'   dBP   dBBBBBP    dBBBBP dBBBBP dBP
+          .dBBBBP  dBBBBBBP dBP dBP    dBBBP  dBP    dBP
+          BP
+          `BBBBb    dBP   dBP dBP    dBP    dBP    dBP
+             dBP   dBP   dBP_dBP    dBP    dBP    dBP
+        dBBBBP'   dBP   dBBBBBP    dBBBBP dBBBBP dBP
         LOGO;
 
         $app->logo($logo);

--- a/bin/cli
+++ b/bin/cli
@@ -14,13 +14,13 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 Init::run(
     function (ContainerInterface $dic): void {
-      /**
-       * @todo Remove after magic dic calls have been purged
-       */
-      global $container;
-      $container = $dic;
+        /**
+         * @todo Remove after magic dic calls have been purged
+         */
+        global $container;
+        $container = $dic;
 
-      $em = $dic->get(EntityManagerInterface::class);
+        $em = $dic->get(EntityManagerInterface::class);
 
         $em->beginTransaction();
 
@@ -45,7 +45,7 @@ Init::run(
               `BBBBb    dBP   dBP dBP    dBP    dBP    dBP
                  dBP   dBP   dBP_dBP    dBP    dBP    dBP
             dBBBBP'   dBP   dBBBBBP    dBBBBP dBBBBP dBP
-            LOGO;
+        LOGO;
 
         $app->logo($logo);
         $app->add(new UserCreateCommand($dic));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12806,6 +12806,91 @@ parameters:
 			path: src/Orm/Entity/Alliance.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\:\\:\\$alliance type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Alliance\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoard.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\:\\:\\$alliance type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceInterface but database expects Stu\\\\Orm\\\\Entity\\\\Alliance\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoard.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\:\\:\\$posts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\AllianceBoardPostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoard.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\:\\:\\$topics type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopicInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoard.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$board type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceBoardInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$board type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoardInterface but database expects Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$topic type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopicInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$topic type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopicInterface but database expects Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$alliance type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Alliance\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$alliance type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceInterface but database expects Stu\\\\Orm\\\\Entity\\\\Alliance\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$board type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceBoardInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$board type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceBoardInterface but database expects Stu\\\\Orm\\\\Entity\\\\AllianceBoard\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$posts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\AllianceBoardPostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\AllianceBoardPost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceBoardTopic\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceBoardTopic.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceJob\\:\\:\\$alliance type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Alliance\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/AllianceJob.php
@@ -12831,37 +12916,72 @@ parameters:
 			path: src/Orm/Entity/AllianceRelation.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceRelation\\:\\:\\$alliance type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Alliance\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceRelation.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceRelation\\:\\:\\$alliance type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceInterface but database expects Stu\\\\Orm\\\\Entity\\\\Alliance\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceRelation.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceRelation\\:\\:\\$opponent type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Alliance\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AllianceInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceRelation.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AllianceRelation\\:\\:\\$opponent type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\AllianceInterface but database expects Stu\\\\Orm\\\\Entity\\\\Alliance\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AllianceRelation.php
+
+		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\AllianceRelationInterface\\:\\:getPossibleTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Orm/Entity/AllianceRelationInterface.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_id_1 is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starSystem type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null but property expects Stu\\\\Orm\\\\Entity\\\\StarSystemInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_id_2 is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starSystem type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemInterface but database expects Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_id_3 is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_1 type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_id_4 is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_2 type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_id_5 is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_3 type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$systems_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_4 type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AstronomicalEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$starsystem_map_5 type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AstronomicalEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AstronomicalEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AstronomicalEntry\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/AstronomicalEntry.php
 
@@ -12871,12 +12991,52 @@ parameters:
 			path: src/Orm/Entity/AuctionBid.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AuctionBid\\:\\:\\$auction type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Deals\\|null but property expects Stu\\\\Orm\\\\Entity\\\\DealsInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AuctionBid.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AuctionBid\\:\\:\\$auction type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DealsInterface but database expects Stu\\\\Orm\\\\Entity\\\\Deals\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AuctionBid.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AuctionBid\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/AuctionBid.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\AuctionBid\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/AuctionBid.php
+
+		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:getUniqId\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/BasicTrade.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$faction_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BasicTrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BasicTrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$date_ms type mapping mismatch\\: database can contain string\\|null but property expects int\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BasicTrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$faction type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Faction\\|null but property expects Stu\\\\Orm\\\\Entity\\\\FactionInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BasicTrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BasicTrade\\:\\:\\$faction type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\FactionInterface but database expects Stu\\\\Orm\\\\Entity\\\\Faction\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/BasicTrade.php
 
@@ -12891,17 +13051,92 @@ parameters:
 			path: src/Orm/Entity/Building.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\:\\:\\$building is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Building\\:\\:\\$commodities type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\BuildingCommodityInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Building.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Building\\:\\:\\$costs type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\BuildingCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\BuildingCost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Building.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Building\\:\\:\\$functions type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\BuildingFunctionInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\BuildingFunction\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Building.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Building\\:\\:\\$possibleFieldTypes type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\PlanetFieldTypeBuildingInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\PlanetFieldTypeBuilding\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Building.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\:\\:\\$building type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/BuildingCommodity.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCost\\:\\:\\$building is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCommodity.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCommodity.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCommodity\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCommodity.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCost\\:\\:\\$building type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/BuildingCost.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFunction\\:\\:\\$building is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCost\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingCost\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFieldAlternative\\:\\:\\$alternateBuilding type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingFieldAlternative.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFieldAlternative\\:\\:\\$alternateBuilding type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingFieldAlternative.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFieldAlternative\\:\\:\\$building type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingFieldAlternative.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFieldAlternative\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingFieldAlternative.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFunction\\:\\:\\$building type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingFunction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingFunction\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/BuildingFunction.php
 
@@ -12911,14 +13146,99 @@ parameters:
 			path: src/Orm/Entity/BuildingUpgrade.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeFromBuilding is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$id type mapping mismatch\\: database can contain string but property expects int\\.$#"
 			count: 1
 			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeCosts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeFromBuilding type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeFromBuilding type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeToBuilding type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\:\\:\\$upgradeToBuilding type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgrade.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\:\\:\\$buildings_upgrades_id type mapping mismatch\\: database can contain string but property expects int\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgradeCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgradeCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgradeCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\:\\:\\$upgrade type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgradeCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeCost\\:\\:\\$upgrade type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingUpgradeInterface but database expects Stu\\\\Orm\\\\Entity\\\\BuildingUpgrade\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildingUpgradeCost.php
 
 		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\BuildplanHangar\\:\\:getDefaultTorpedoTypeId\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/BuildplanHangar.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanHangar\\:\\:\\$buildplan type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanHangar.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanHangar\\:\\:\\$buildplan type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanHangar.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanHangar\\:\\:\\$defaultTorpedoType type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TorpedoTypeInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TorpedoType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanHangar.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanModule\\:\\:\\$buildplan type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanModule.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanModule\\:\\:\\$buildplan type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanModule.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanModule\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanModule.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\BuildplanModule\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/BuildplanModule.php
 
 		-
 			message: "#^Cannot call method getSectorString\\(\\) on Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null\\.$#"
@@ -12966,6 +13286,51 @@ parameters:
 			path: src/Orm/Entity/Colony.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$blockers type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\FleetInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Fleet\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$colonyClass type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ColonyClass\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyClassInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$colonyClass type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyClassInterface but database expects Stu\\\\Orm\\\\Entity\\\\ColonyClass\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$crewAssignments type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipCrewInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipCrew\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$crewTrainings type mapping mismatch\\: database can contain Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\CrewTraining\\> but property expects Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipCrewInterface\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$crewTrainings type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipCrewInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\CrewTraining\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$defenders type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\FleetInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Fleet\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$depositMinings type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ColonyDepositMiningInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ColonyDepositMining\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$planetFields type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\PlanetFieldInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\PlanetField\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$production \\(array\\<int, Stu\\\\Lib\\\\ColonyProduction\\\\ColonyProduction\\>\\|null\\) does not accept array\\<int\\|string, Stu\\\\Lib\\\\ColonyProduction\\\\ColonyProduction\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/Colony.php
@@ -12981,12 +13346,32 @@ parameters:
 			path: src/Orm/Entity/Colony.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$starsystem_map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$starsystem_map type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null but property expects Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/Colony.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$torpedo_type is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$starsystem_map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$storage type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\StorageInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Storage\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$torpedo type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TorpedoTypeInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TorpedoType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Colony.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Colony\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/Colony.php
 
@@ -13046,12 +13431,22 @@ parameters:
 			path: src/Orm/Entity/ColonyClassInterface.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$planet_type_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$colonyClass type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ColonyClass\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyClassInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/ColonyClassResearch.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$research_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$colonyClass type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyClassInterface but database expects Stu\\\\Orm\\\\Entity\\\\ColonyClass\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyClassResearch.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$research type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Research\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ResearchInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyClassResearch.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyClassResearch\\:\\:\\$research type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ResearchInterface but database expects Stu\\\\Orm\\\\Entity\\\\Research\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ColonyClassResearch.php
 
@@ -13091,6 +13486,36 @@ parameters:
 			path: src/Orm/Entity/ColonyDepositMining.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$shipBuildplan type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$shipBuildplan type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$shipRump type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipQueue\\:\\:\\$shipRump type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyShipQueue.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyShipRepair\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/ColonyShipRepair.php
@@ -13111,7 +13536,52 @@ parameters:
 			path: src/Orm/Entity/ColonyShipRepair.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$field type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\PlanetField\\|null but property expects Stu\\\\Orm\\\\Entity\\\\PlanetFieldInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$field type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\PlanetFieldInterface but database expects Stu\\\\Orm\\\\Entity\\\\PlanetField\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$terraforming type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Terraforming\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TerraformingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ColonyTerraforming\\:\\:\\$terraforming type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TerraformingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Terraforming\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ColonyTerraforming.php
+
+		-
 			message: "#^Access to an undefined property Stu\\\\Orm\\\\Entity\\\\ConstructionProgress\\:\\:\\$getId\\.$#"
+			count: 1
+			path: src/Orm/Entity/ConstructionProgress.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ConstructionProgress\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ConstructionProgress.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ConstructionProgress\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ConstructionProgress.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ConstructionProgress\\:\\:\\$specialModules type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ConstructionProgressModuleInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ConstructionProgressModule\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/ConstructionProgress.php
 
@@ -13134,6 +13604,26 @@ parameters:
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ConstructionProgressModule\\:\\:\\$progress type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ConstructionProgressInterface but database expects Stu\\\\Orm\\\\Entity\\\\ConstructionProgress\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ConstructionProgressModule.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Contact\\:\\:\\$opponent type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Contact.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Contact\\:\\:\\$opponent type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Contact.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Contact\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Contact.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Contact\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Contact.php
 
 		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Crew\\:\\:\\$race type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\CrewRace\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CrewRaceInterface\\.$#"
@@ -13166,6 +13656,26 @@ parameters:
 			path: src/Orm/Entity/CrewRace.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\CrewTraining\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/CrewTraining.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\CrewTraining\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/CrewTraining.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\CrewTraining\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/CrewTraining.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\CrewTraining\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/CrewTraining.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseCategory\\:\\:\\$award type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Award\\|null but property expects Stu\\\\Orm\\\\Entity\\\\AwardInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/DatabaseCategory.php
@@ -13179,6 +13689,46 @@ parameters:
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseCategory\\:\\:\\$entries type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\DatabaseEntryInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/DatabaseCategory.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\:\\:\\$category type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\DatabaseCategory\\|null but property expects Stu\\\\Orm\\\\Entity\\\\DatabaseCategoryInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\:\\:\\$category type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DatabaseCategoryInterface but database expects Stu\\\\Orm\\\\Entity\\\\DatabaseCategory\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\:\\:\\$type_object type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\DatabaseType\\|null but property expects Stu\\\\Orm\\\\Entity\\\\DatabaseTypeInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\:\\:\\$type_object type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DatabaseTypeInterface but database expects Stu\\\\Orm\\\\Entity\\\\DatabaseType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseEntry.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseUser\\:\\:\\$databaseEntry type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\|null but property expects Stu\\\\Orm\\\\Entity\\\\DatabaseEntryInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseUser.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseUser\\:\\:\\$databaseEntry type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DatabaseEntryInterface but database expects Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseUser.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseUser\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseUser.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DatabaseUser\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/DatabaseUser.php
 
 		-
 			message: "#^Cannot call method getModules\\(\\) on Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\|null\\.$#"
@@ -13231,6 +13781,16 @@ parameters:
 			path: src/Orm/Entity/Deals.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DockingPrivilege\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/DockingPrivilege.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\DockingPrivilege\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/DockingPrivilege.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Faction\\:\\:\\$start_research type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ResearchInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Research\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/Faction.php
@@ -13251,17 +13811,7 @@ parameters:
 			path: src/Orm/Entity/Fleet.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Fleet\\:\\:\\$blocked_colony_id is unused\\.$#"
-			count: 1
-			path: src/Orm/Entity/Fleet.php
-
-		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Fleet\\:\\:\\$defendedColony has no type specified\\.$#"
-			count: 1
-			path: src/Orm/Entity/Fleet.php
-
-		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Fleet\\:\\:\\$defended_colony_id is unused\\.$#"
 			count: 1
 			path: src/Orm/Entity/Fleet.php
 
@@ -13286,12 +13836,22 @@ parameters:
 			path: src/Orm/Entity/FleetInterface.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Map\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/FlightSignature.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$starsystem_map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$rump type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/FlightSignature.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$rump type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/FlightSignature.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\FlightSignature\\:\\:\\$starsystem_map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/FlightSignature.php
 
@@ -13306,6 +13866,11 @@ parameters:
 			path: src/Orm/Entity/GameRequestInterface.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\GameTurn\\:\\:\\$stats type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\GameTurnStatsInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\GameTurnStats\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/GameTurn.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\GameTurnStats\\:\\:\\$turn type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\GameTurn\\|null but property expects Stu\\\\Orm\\\\Entity\\\\GameTurnInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/GameTurnStats.php
@@ -13316,7 +13881,67 @@ parameters:
 			path: src/Orm/Entity/GameTurnStats.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\IgnoreList\\:\\:\\$opponent type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/IgnoreList.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\IgnoreList\\:\\:\\$opponent type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/IgnoreList.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\IgnoreList\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/IgnoreList.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\IgnoreList\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/IgnoreList.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnComment\\:\\:\\$post type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\KnPost\\|null but property expects Stu\\\\Orm\\\\Entity\\\\KnPostInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnComment.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnComment\\:\\:\\$post type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\KnPostInterface but database expects Stu\\\\Orm\\\\Entity\\\\KnPost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnComment.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnComment\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnComment.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnComment\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnComment.php
+
+		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\KnPost\\:\\:getUserId\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnPost\\:\\:\\$comments type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\KnCommentInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\KnComment\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnPost\\:\\:\\$rpgPlot type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\RpgPlotInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\RpgPlot\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnPost\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/KnPost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\KnPost\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/KnPost.php
 
@@ -13356,17 +13981,72 @@ parameters:
 			path: src/Orm/Entity/Map.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$admin_region_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$administratedRegion type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapRegionInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\MapRegion\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/Map.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$layer_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$influenceArea type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$layer type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Layer\\|null but property expects Stu\\\\Orm\\\\Entity\\\\LayerInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$layer type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\LayerInterface but database expects Stu\\\\Orm\\\\Entity\\\\Layer\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$mapBorderType type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapBorderTypeInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\MapBorderType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$mapFieldType type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\MapFieldType\\|null but property expects Stu\\\\Orm\\\\Entity\\\\MapFieldTypeInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$mapFieldType type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapFieldTypeInterface but database expects Stu\\\\Orm\\\\Entity\\\\MapFieldType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$mapRegion type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapRegionInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\MapRegion\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$ships type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Ship\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$signatures type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\FlightSignatureInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\FlightSignature\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$starSystem type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Map.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Map\\:\\:\\$wormholeEntries type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\WormholeEntryInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\WormholeEntry\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/Map.php
 
 		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\MapFieldType\\:\\:getColonyClassId\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/MapFieldType.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\MapFieldType\\:\\:\\$colonyClass type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyClassInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\ColonyClass\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/MapFieldType.php
 
@@ -13391,17 +14071,72 @@ parameters:
 			path: src/Orm/Entity/Module.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$research is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$buildingCosts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ModuleCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ModuleCost\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/Module.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$shipRumpRole is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/Module.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleCost\\:\\:\\$module is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$moduleSpecials type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ModuleSpecialInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ModuleSpecial\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$research type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Research\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ResearchInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$research type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ResearchInterface but database expects Stu\\\\Orm\\\\Entity\\\\Research\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$shipRumpRole type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpRole\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpRoleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Module\\:\\:\\$shipRumpRole type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpRoleInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRumpRole\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Module.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleBuildingFunction\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleBuildingFunction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleBuildingFunction\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleBuildingFunction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleCost\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleCost\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleCost\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ModuleCost.php
 
@@ -13411,9 +14146,44 @@ parameters:
 			path: src/Orm/Entity/ModuleInterface.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleSpecial\\:\\:\\$module is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleQueue\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleQueue\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleQueue\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleQueue\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleSpecial\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/ModuleSpecial.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ModuleSpecial\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ModuleSpecial.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Note\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Note.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Note\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Note.php
 
 		-
 			message: "#^Cannot call method getBuildTime\\(\\) on Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\|null\\.$#"
@@ -13476,14 +14246,79 @@ parameters:
 			path: src/Orm/Entity/PlanetField.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetField\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PlanetField.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetField\\:\\:\\$colony type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Colony\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/PlanetField.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetField\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PlanetField.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetField\\:\\:\\$terraforming type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TerraformingInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Terraforming\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PlanetField.php
+
+		-
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Orm/Entity/PlanetField.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetFieldTypeBuilding\\:\\:\\$building is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetFieldTypeBuilding\\:\\:\\$building type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Building\\|null but property expects Stu\\\\Orm\\\\Entity\\\\BuildingInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/PlanetFieldTypeBuilding.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PlanetFieldTypeBuilding\\:\\:\\$building type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\BuildingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Building\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PlanetFieldTypeBuilding.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$category type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolder\\|null but property expects Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolderInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$category type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolderInterface but database expects Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolder\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$receivingUser type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$receivingUser type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$sendingUser type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessage\\:\\:\\$sendingUser type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessage.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolder\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessageFolder.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\PrivateMessageFolder\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/PrivateMessageFolder.php
 
 		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RepairTask\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
@@ -13581,7 +14416,57 @@ parameters:
 			path: src/Orm/Entity/Researched.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlot\\:\\:\\$members type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\RpgPlotMemberInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\RpgPlotMember\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlot.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlot\\:\\:\\$posts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\KnPostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\KnPost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlot.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlot\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlot.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlot\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlot.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlotMember\\:\\:\\$rpgPlot type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\RpgPlot\\|null but property expects Stu\\\\Orm\\\\Entity\\\\RpgPlotInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlotMember.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlotMember\\:\\:\\$rpgPlot type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\RpgPlotInterface but database expects Stu\\\\Orm\\\\Entity\\\\RpgPlot\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlotMember.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlotMember\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlotMember.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\RpgPlotMember\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/RpgPlotMember.php
+
+		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\SessionString\\:\\:getDate\\(\\) should return DateTimeInterface but returns DateTimeInterface\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/SessionString.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\SessionString\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/SessionString.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\SessionString\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/SessionString.php
 
@@ -13656,22 +14541,107 @@ parameters:
 			path: src/Orm/Entity/Ship.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$influence_area_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$buildplan type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/Ship.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$crew type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipCrewInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipCrew\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/Ship.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$plans_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$dockedShips type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Ship\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/Ship.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$starsystem_map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$dockedTo type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$dockingPrivileges type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\DockingPrivilegeInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\DockingPrivilege\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$fleet type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\FleetInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Fleet\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$holdingWeb type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TholianWebInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TholianWeb\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$influenceArea type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$logbook type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipLogInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipLog\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Map\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$rump type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$rump type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$starsystem_map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$storage type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\StorageInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Storage\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$systems type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipSystemInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipSystem\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$torpedoStorage type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TorpedoStorageInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TorpedoStorage\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$tractoredShip type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$tractoringShip type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$tradePost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/Ship.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Ship\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/Ship.php
 
@@ -13726,17 +14696,42 @@ parameters:
 			path: src/Orm/Entity/ShipCrew.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$colony_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipCrew.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$repair_task_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$crew type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Crew\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CrewInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipCrew.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$tradepost_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$crew type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CrewInterface but database expects Stu\\\\Orm\\\\Entity\\\\Crew\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$repairTask type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\RepairTaskInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\RepairTask\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$tradepost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipCrew\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipCrew.php
 
@@ -13756,12 +14751,52 @@ parameters:
 			path: src/Orm/Entity/ShipInterface.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipLog\\:\\:\\$ship_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipLog\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipLog.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipLog\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipLog.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$buildingCosts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipRumpCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$databaseEntry type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DatabaseEntryInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$role_id \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$role_id type mapping mismatch\\: database can contain int\\|null but property expects int\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$shipRumpCategory type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpCategory\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpCategoryInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$shipRumpCategory type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpCategoryInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRumpCategory\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRump.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRump\\:\\:\\$shipRumpRole type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpRoleInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\ShipRumpRole\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipRump.php
 
@@ -13776,7 +14811,32 @@ parameters:
 			path: src/Orm/Entity/ShipRumpCategory.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\:\\:\\$shipRump is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCategoryRoleCrew\\:\\:\\$shiprumpRole type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpRole\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpRoleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRumpCategoryRoleCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCategoryRoleCrew\\:\\:\\$shiprumpRole type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpRoleInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRumpRole\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRumpCategoryRoleCrew.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRumpCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRumpCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\:\\:\\$shipRump type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipRumpCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipRumpCost\\:\\:\\$shipRump type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/ShipRumpCost.php
 
@@ -13791,12 +14851,142 @@ parameters:
 			path: src/Orm/Entity/ShipSystem.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipSystem\\:\\:\\$module type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Module\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ModuleInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipSystem\\:\\:\\$module type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ModuleInterface but database expects Stu\\\\Orm\\\\Entity\\\\Module\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipSystem\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipSystem\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$shipBuildplan type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$shipBuildplan type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipBuildplanInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipBuildplan\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$shipRump type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\ShipyardShipQueue\\:\\:\\$shipRump type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipRumpInterface but database expects Stu\\\\Orm\\\\Entity\\\\ShipRump\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/ShipyardShipQueue.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\SpacecraftEmergency\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/SpacecraftEmergency.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\SpacecraftEmergency\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/SpacecraftEmergency.php
+
+		-
 			message: "#^Cannot call method getLayer\\(\\) on Stu\\\\Orm\\\\Entity\\\\MapInterface\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/StarSystem.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$base type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$databaseEntry type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\DatabaseEntryInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\DatabaseEntry\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$map type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Map\\|null but property expects Stu\\\\Orm\\\\Entity\\\\MapInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapInterface but database expects Stu\\\\Orm\\\\Entity\\\\Map\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$systemType type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\StarSystemType\\|null but property expects Stu\\\\Orm\\\\Entity\\\\StarSystemTypeInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystem\\:\\:\\$systemType type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemTypeInterface but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystem.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$colony type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ColonyInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Colony\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$mapFieldType type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\MapFieldType\\|null but property expects Stu\\\\Orm\\\\Entity\\\\MapFieldTypeInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$mapFieldType type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapFieldTypeInterface but database expects Stu\\\\Orm\\\\Entity\\\\MapFieldType\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$ships type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Ship\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$signatures type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\FlightSignatureInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\FlightSignature\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$starSystem type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null but property expects Stu\\\\Orm\\\\Entity\\\\StarSystemInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$starSystem type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemInterface but database expects Stu\\\\Orm\\\\Entity\\\\StarSystem\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/StarSystemMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\:\\:\\$wormholeEntries type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\WormholeEntryInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\WormholeEntry\\>\\.$#"
 			count: 1
 			path: src/Orm/Entity/StarSystemMap.php
 
@@ -13876,14 +15066,64 @@ parameters:
 			path: src/Orm/Entity/Storage.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\MapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\Map\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/TachyonScan.php
 
 		-
-			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$starsystem_map_id is unused\\.$#"
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$starsystem_map type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StarSystemMapInterface\\|null but database expects Stu\\\\Orm\\\\Entity\\\\StarSystemMap\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/TachyonScan.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TachyonScan.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TachyonScan\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TachyonScan.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\Terraforming\\:\\:\\$costs type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\TerraformingCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\TerraformingCost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/Terraforming.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TerraformingCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TerraformingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TerraformingCost\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TerraformingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TerraformingCost\\:\\:\\$terraforming type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Terraforming\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TerraformingInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TerraformingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TerraformingCost\\:\\:\\$terraforming type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TerraformingInterface but database expects Stu\\\\Orm\\\\Entity\\\\Terraforming\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TerraformingCost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TholianWeb\\:\\:\\$capturedShips type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\Ship\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/TholianWeb.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TholianWeb\\:\\:\\$webShip type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TholianWeb.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TholianWeb\\:\\:\\$webShip type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TholianWeb.php
 
 		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TorpedoStorage\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
@@ -13916,6 +15156,21 @@ parameters:
 			path: src/Orm/Entity/TorpedoStorage.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TorpedoType\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TorpedoType.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TorpedoType\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TorpedoType.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TorpedoType\\:\\:\\$productionCosts type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\TorpedoTypeCostInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\TorpedoTypeCost\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/TorpedoType.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TorpedoTypeCost\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/TorpedoTypeCost.php
@@ -13936,9 +15191,104 @@ parameters:
 			path: src/Orm/Entity/TorpedoTypeCost.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicense\\:\\:\\$tradePost type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\TradePost\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicense.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicense\\:\\:\\$tradePost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicense.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicense\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicense.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicense\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicense.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\:\\:\\$commodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicenseInfo.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\:\\:\\$commodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicenseInfo.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\:\\:\\$id has no type specified\\.$#"
 			count: 1
 			path: src/Orm/Entity/TradeLicenseInfo.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\:\\:\\$tradePost type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\TradePost\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicenseInfo.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\:\\:\\$tradePost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeLicenseInfo.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$offeredCommodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$offeredCommodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$storage type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Storage\\|null but property expects Stu\\\\Orm\\\\Entity\\\\StorageInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$storage type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\StorageInterface but database expects Stu\\\\Orm\\\\Entity\\\\Storage\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$tradePost type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\TradePost\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$tradePost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$wantedCommodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeOffer\\:\\:\\$wantedCommodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeOffer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$crewAssignments type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\ShipCrewInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\ShipCrew\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
 
 		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$licenseInfos \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfoInterface\\>\\) in empty\\(\\) is not falsy\\.$#"
@@ -13946,9 +15296,84 @@ parameters:
 			path: src/Orm/Entity/TradePost.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$licenseInfos type mapping mismatch\\: property can contain Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\<int, Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfoInterface\\> but database expects Doctrine\\\\Common\\\\Collections\\\\Collection&iterable\\<Stu\\\\Orm\\\\Entity\\\\TradeLicenseInfo\\>\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$ship type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Ship\\|null but property expects Stu\\\\Orm\\\\Entity\\\\ShipInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$ship type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\ShipInterface but database expects Stu\\\\Orm\\\\Entity\\\\Ship\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradePost\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradePost.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeShoutbox\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeShoutbox.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeShoutbox\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeShoutbox.php
+
+		-
 			message: "#^Method Stu\\\\Orm\\\\Entity\\\\TradeTransaction\\:\\:getTradePostId\\(\\) should return int but returns int\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/TradeTransaction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransaction\\:\\:\\$offeredCommodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransaction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransaction\\:\\:\\$offeredCommodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransaction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransaction\\:\\:\\$wantedCommodity type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Commodity\\|null but property expects Stu\\\\Orm\\\\Entity\\\\CommodityInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransaction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransaction\\:\\:\\$wantedCommodity type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\CommodityInterface but database expects Stu\\\\Orm\\\\Entity\\\\Commodity\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransaction.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransfer\\:\\:\\$tradePost type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\TradePost\\|null but property expects Stu\\\\Orm\\\\Entity\\\\TradePostInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransfer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransfer\\:\\:\\$tradePost type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\TradePostInterface but database expects Stu\\\\Orm\\\\Entity\\\\TradePost\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransfer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransfer\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransfer.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\TradeTransfer\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/TradeTransfer.php
 
 		-
 			message: "#^Cannot call method isExplored\\(\\) on Stu\\\\Orm\\\\Entity\\\\UserLayerInterface\\|null\\.$#"
@@ -14031,6 +15456,16 @@ parameters:
 			path: src/Orm/Entity/UserInterface.php
 
 		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserIpTable\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserIpTable.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserIpTable\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserIpTable.php
+
+		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserLayer\\:\\:\\$layer type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\Layer\\|null but property expects Stu\\\\Orm\\\\Entity\\\\LayerInterface\\.$#"
 			count: 1
 			path: src/Orm/Entity/UserLayer.php
@@ -14089,6 +15524,26 @@ parameters:
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserMap\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
 			count: 1
 			path: src/Orm/Entity/UserMap.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserProfileVisitor\\:\\:\\$opponent type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserProfileVisitor.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserProfileVisitor\\:\\:\\$opponent type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserProfileVisitor.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserProfileVisitor\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserProfileVisitor.php
+
+		-
+			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserProfileVisitor\\:\\:\\$user type mapping mismatch\\: property can contain Stu\\\\Orm\\\\Entity\\\\UserInterface but database expects Stu\\\\Orm\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Orm/Entity/UserProfileVisitor.php
 
 		-
 			message: "#^Property Stu\\\\Orm\\\\Entity\\\\UserTag\\:\\:\\$user type mapping mismatch\\: database can contain Stu\\\\Orm\\\\Entity\\\\User\\|null but property expects Stu\\\\Orm\\\\Entity\\\\UserInterface\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,7 +7,6 @@ parameters:
     - src/html
   ignoreErrors:
     - '#Property Stu\\Orm\\Entity\\(\w+)::\$(\w+) is never written, only read#'
-    - '#Property Stu\\Orm\\Entity\\(\w+)::\$(\w+) is never read, only written#'
 
 includes:
   - vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/Module/Control/GameController.php
+++ b/src/Module/Control/GameController.php
@@ -4,6 +4,7 @@ namespace Stu\Module\Control;
 
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
+use Exception;
 use Stu\Exception\SessionInvalidException;
 use Noodlehaus\ConfigInterface;
 use request;

--- a/src/Orm/Entity/AllianceBoard.php
+++ b/src/Orm/Entity/AllianceBoard.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Orm\Repository\AllianceBoardPostRepositoryInterface;
 
 /**

--- a/src/Orm/Entity/AllianceBoardPost.php
+++ b/src/Orm/Entity/AllianceBoardPost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\AllianceBoardPostRepository")

--- a/src/Orm/Entity/AllianceBoardTopic.php
+++ b/src/Orm/Entity/AllianceBoardTopic.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Module\Alliance\View\Topic\Topic;
 use Stu\Orm\Repository\AllianceBoardPostRepositoryInterface;
 

--- a/src/Orm/Entity/AllianceRelation.php
+++ b/src/Orm/Entity/AllianceRelation.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Alliance\AllianceEnum;
 
 /**

--- a/src/Orm/Entity/AstronomicalEntry.php
+++ b/src/Orm/Entity/AstronomicalEntry.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\AstroEntryRepository")

--- a/src/Orm/Entity/AuctionBid.php
+++ b/src/Orm/Entity/AuctionBid.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\AuctionBidRepository")

--- a/src/Orm/Entity/BasicTrade.php
+++ b/src/Orm/Entity/BasicTrade.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BasicTradeRepository")

--- a/src/Orm/Entity/Building.php
+++ b/src/Orm/Entity/Building.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Building\BuildingEnum;
 use Stu\Module\Building\Action\BuildingFunctionActionMapperInterface;
 

--- a/src/Orm/Entity/BuildingCommodity.php
+++ b/src/Orm/Entity/BuildingCommodity.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingCommodityRepository")

--- a/src/Orm/Entity/BuildingCost.php
+++ b/src/Orm/Entity/BuildingCost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingCostRepository")

--- a/src/Orm/Entity/BuildingFieldAlternative.php
+++ b/src/Orm/Entity/BuildingFieldAlternative.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingFieldAlternativeRepository")

--- a/src/Orm/Entity/BuildingFunction.php
+++ b/src/Orm/Entity/BuildingFunction.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingFunctionRepository")

--- a/src/Orm/Entity/BuildingUpgrade.php
+++ b/src/Orm/Entity/BuildingUpgrade.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingUpgradeRepository")

--- a/src/Orm/Entity/BuildingUpgradeCost.php
+++ b/src/Orm/Entity/BuildingUpgradeCost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildingUpgradeCostRepository")

--- a/src/Orm/Entity/BuildplanHangar.php
+++ b/src/Orm/Entity/BuildplanHangar.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildplanHangarRepository")

--- a/src/Orm/Entity/BuildplanModule.php
+++ b/src/Orm/Entity/BuildplanModule.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\BuildplanModuleRepository")

--- a/src/Orm/Entity/Colony.php
+++ b/src/Orm/Entity/Colony.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Building\BuildingEnum;
 use Stu\Component\Colony\ColonyEnum;
 use Stu\Component\Faction\FactionEnum;

--- a/src/Orm/Entity/ColonyClassResearch.php
+++ b/src/Orm/Entity/ColonyClassResearch.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ColonyClassResearchRepository")

--- a/src/Orm/Entity/ColonyShipQueue.php
+++ b/src/Orm/Entity/ColonyShipQueue.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ColonyShipQueueRepository")

--- a/src/Orm/Entity/ColonyTerraforming.php
+++ b/src/Orm/Entity/ColonyTerraforming.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ColonyTerraformingRepository")

--- a/src/Orm/Entity/ConstructionProgress.php
+++ b/src/Orm/Entity/ConstructionProgress.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ConstructionProgressRepository")

--- a/src/Orm/Entity/Contact.php
+++ b/src/Orm/Entity/Contact.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Module\Message\Lib\ContactListModeEnum;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ContactRepository")

--- a/src/Orm/Entity/CrewTraining.php
+++ b/src/Orm/Entity/CrewTraining.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\CrewTrainingRepository")

--- a/src/Orm/Entity/DatabaseEntry.php
+++ b/src/Orm/Entity/DatabaseEntry.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\DatabaseEntryRepository")

--- a/src/Orm/Entity/DatabaseUser.php
+++ b/src/Orm/Entity/DatabaseUser.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\DatabaseUserRepository")

--- a/src/Orm/Entity/DockingPrivilege.php
+++ b/src/Orm/Entity/DockingPrivilege.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Ship\ShipEnum;
 use Stu\Orm\Repository\AllianceRepositoryInterface;
 use Stu\Orm\Repository\FactionRepositoryInterface;

--- a/src/Orm/Entity/Fleet.php
+++ b/src/Orm/Entity/Fleet.php
@@ -13,8 +13,10 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
+use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\FleetRepository")

--- a/src/Orm/Entity/FlightSignature.php
+++ b/src/Orm/Entity/FlightSignature.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\FlightSignatureRepository")

--- a/src/Orm/Entity/GameConfig.php
+++ b/src/Orm/Entity/GameConfig.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\GameConfigRepository")

--- a/src/Orm/Entity/GameRequest.php
+++ b/src/Orm/Entity/GameRequest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\GameRequestRepository")

--- a/src/Orm/Entity/GameTurn.php
+++ b/src/Orm/Entity/GameTurn.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\GameTurnRepository")

--- a/src/Orm/Entity/History.php
+++ b/src/Orm/Entity/History.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\HistoryRepository")

--- a/src/Orm/Entity/IgnoreList.php
+++ b/src/Orm/Entity/IgnoreList.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\IgnoreListRepository")

--- a/src/Orm/Entity/KnComment.php
+++ b/src/Orm/Entity/KnComment.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\KnCommentRepository")

--- a/src/Orm/Entity/KnPost.php
+++ b/src/Orm/Entity/KnPost.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Module\Communication\View\ShowSingleKn\ShowSingleKn;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\KnPostRepository")

--- a/src/Orm/Entity/Map.php
+++ b/src/Orm/Entity/Map.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Map\MapEnum;
 
 /**

--- a/src/Orm/Entity/MapFieldType.php
+++ b/src/Orm/Entity/MapFieldType.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\MapFieldTypeRepository")

--- a/src/Orm/Entity/Module.php
+++ b/src/Orm/Entity/Module.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Module\ShipModule\ModuleTypeDescriptionMapper;
 
 /**

--- a/src/Orm/Entity/ModuleBuildingFunction.php
+++ b/src/Orm/Entity/ModuleBuildingFunction.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ModuleBuildingFunctionRepository")

--- a/src/Orm/Entity/ModuleCost.php
+++ b/src/Orm/Entity/ModuleCost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ModuleCostRepository")

--- a/src/Orm/Entity/ModuleQueue.php
+++ b/src/Orm/Entity/ModuleQueue.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ModuleQueueRepository")

--- a/src/Orm/Entity/ModuleSpecial.php
+++ b/src/Orm/Entity/ModuleSpecial.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Module\ShipModule\ModuleSpecialAbilityEnum;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ModuleSpecialRepository")

--- a/src/Orm/Entity/News.php
+++ b/src/Orm/Entity/News.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\NewsRepository")

--- a/src/Orm/Entity/Note.php
+++ b/src/Orm/Entity/Note.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\NoteRepository")

--- a/src/Orm/Entity/PlanetField.php
+++ b/src/Orm/Entity/PlanetField.php
@@ -20,6 +20,7 @@ use Stu\Module\Tal\TalStatusBar;
 use Stu\Orm\Repository\BuildingUpgradeRepositoryInterface;
 use Stu\Orm\Repository\ColonyTerraformingRepositoryInterface;
 use Stu\Orm\Repository\TerraformingRepositoryInterface;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PlanetFieldRepository")

--- a/src/Orm/Entity/PlanetFieldType.php
+++ b/src/Orm/Entity/PlanetFieldType.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PlanetFieldTypeRepository")

--- a/src/Orm/Entity/PlanetFieldTypeBuilding.php
+++ b/src/Orm/Entity/PlanetFieldTypeBuilding.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Module\Colony\Lib\PlanetFieldTypeRetrieverInterface;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PlanetFieldTypeBuildingRepository")

--- a/src/Orm/Entity/PrestigeLog.php
+++ b/src/Orm/Entity/PrestigeLog.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PrestigeLogRepository")

--- a/src/Orm/Entity/PrivateMessage.php
+++ b/src/Orm/Entity/PrivateMessage.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PrivateMessageRepository")

--- a/src/Orm/Entity/PrivateMessageFolder.php
+++ b/src/Orm/Entity/PrivateMessageFolder.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\Table;
 use Stu\Module\Message\Lib\PrivateMessageFolderSpecialEnum;
 use Stu\Orm\Repository\PrivateMessageFolderRepositoryInterface;
 use Stu\Orm\Repository\PrivateMessageRepositoryInterface;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\PrivateMessageFolderRepository")

--- a/src/Orm/Entity/RpgPlot.php
+++ b/src/Orm/Entity/RpgPlot.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\RpgPlotRepository")

--- a/src/Orm/Entity/RpgPlotMember.php
+++ b/src/Orm/Entity/RpgPlotMember.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\RpgPlotMemberRepository")

--- a/src/Orm/Entity/SessionString.php
+++ b/src/Orm/Entity/SessionString.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\SessionStringRepository")

--- a/src/Orm/Entity/Ship.php
+++ b/src/Orm/Entity/Ship.php
@@ -32,6 +32,7 @@ use Stu\Component\Ship\System\Type\TroopQuartersShipSystem;
 use Stu\Component\Station\StationUtility;
 use Stu\Module\Control\GameControllerInterface;
 use Stu\Module\Logging\LoggerUtilInterface;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRepository")

--- a/src/Orm/Entity/ShipCrew.php
+++ b/src/Orm/Entity/ShipCrew.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Component\Crew\CrewEnum;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipCrewRepository")

--- a/src/Orm/Entity/ShipLog.php
+++ b/src/Orm/Entity/ShipLog.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipLogRepository")

--- a/src/Orm/Entity/ShipRump.php
+++ b/src/Orm/Entity/ShipRump.php
@@ -18,6 +18,7 @@ use Stu\Component\Ship\ShipRumpEnum;
 use Stu\Orm\Repository\ShipRumpCategoryRoleCrewRepositoryInterface;
 use Stu\Orm\Repository\ShipRumpModuleLevelRepositoryInterface;
 use Stu\Orm\Repository\ShipRumpSpecialRepositoryInterface;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpRepository")

--- a/src/Orm/Entity/ShipRumpBuildingFunction.php
+++ b/src/Orm/Entity/ShipRumpBuildingFunction.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpBuildingFunctionRepository")

--- a/src/Orm/Entity/ShipRumpCategoryRoleCrew.php
+++ b/src/Orm/Entity/ShipRumpCategoryRoleCrew.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpCategoryRoleCrewRepository")

--- a/src/Orm/Entity/ShipRumpColonizationBuilding.php
+++ b/src/Orm/Entity/ShipRumpColonizationBuilding.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpColonizationBuildingRepository")

--- a/src/Orm/Entity/ShipRumpCost.php
+++ b/src/Orm/Entity/ShipRumpCost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpCostRepository")

--- a/src/Orm/Entity/ShipRumpModuleLevel.php
+++ b/src/Orm/Entity/ShipRumpModuleLevel.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpModuleLevelRepository")

--- a/src/Orm/Entity/ShipRumpModuleSpecial.php
+++ b/src/Orm/Entity/ShipRumpModuleSpecial.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity

--- a/src/Orm/Entity/ShipRumpSpecial.php
+++ b/src/Orm/Entity/ShipRumpSpecial.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpSpecialRepository")

--- a/src/Orm/Entity/ShipRumpUser.php
+++ b/src/Orm/Entity/ShipRumpUser.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipRumpUserRepository")

--- a/src/Orm/Entity/ShipSystem.php
+++ b/src/Orm/Entity/ShipSystem.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Component\Ship\System\ShipSystemTypeEnum;
 
 /**

--- a/src/Orm/Entity/ShipyardShipQueue.php
+++ b/src/Orm/Entity/ShipyardShipQueue.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\ShipyardShipQueueRepository")

--- a/src/Orm/Entity/SpacecraftEmergency.php
+++ b/src/Orm/Entity/SpacecraftEmergency.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\SpacecraftEmergencyRepository")

--- a/src/Orm/Entity/StarSystem.php
+++ b/src/Orm/Entity/StarSystem.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 use Stu\Orm\Repository\StarSystemMapRepositoryInterface;
 
 /**

--- a/src/Orm/Entity/StarSystemMap.php
+++ b/src/Orm/Entity/StarSystemMap.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 use Stu\Component\Map\MapEnum;
 
 /**

--- a/src/Orm/Entity/TachyonScan.php
+++ b/src/Orm/Entity/TachyonScan.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TachyonScanRepository")

--- a/src/Orm/Entity/Terraforming.php
+++ b/src/Orm/Entity/Terraforming.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
+use Doctrine\ORM\Mapping\UniqueConstraint;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TerraformingRepository")

--- a/src/Orm/Entity/TerraformingCost.php
+++ b/src/Orm/Entity/TerraformingCost.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TerraformingCostRepository")

--- a/src/Orm/Entity/TholianWeb.php
+++ b/src/Orm/Entity/TholianWeb.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TholianWebRepository")

--- a/src/Orm/Entity/TorpedoType.php
+++ b/src/Orm/Entity/TorpedoType.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToMany;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TorpedoTypeRepository")

--- a/src/Orm/Entity/TradeLicense.php
+++ b/src/Orm/Entity/TradeLicense.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Component\Game\TimeConstants;
 use Stu\Module\Control\StuTime;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeLicenseRepository")

--- a/src/Orm/Entity/TradeLicenseInfo.php
+++ b/src/Orm/Entity/TradeLicenseInfo.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeLicenseInfoRepository")

--- a/src/Orm/Entity/TradeOffer.php
+++ b/src/Orm/Entity/TradeOffer.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\OneToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeOfferRepository")

--- a/src/Orm/Entity/TradePost.php
+++ b/src/Orm/Entity/TradePost.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping\OrderBy;
 use Doctrine\ORM\Mapping\Table;
 use Stu\Module\Control\GameControllerInterface;
 use Stu\Module\PlayerSetting\Lib\UserEnum;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradePostRepository")

--- a/src/Orm/Entity/TradeShoutbox.php
+++ b/src/Orm/Entity/TradeShoutbox.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeShoutboxRepository")

--- a/src/Orm/Entity/TradeTransaction.php
+++ b/src/Orm/Entity/TradeTransaction.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeTransactionRepository")

--- a/src/Orm/Entity/TradeTransfer.php
+++ b/src/Orm/Entity/TradeTransfer.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\TradeTransferRepository")

--- a/src/Orm/Entity/UserInvitation.php
+++ b/src/Orm/Entity/UserInvitation.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\UserInvitationRepository")

--- a/src/Orm/Entity/UserIpTable.php
+++ b/src/Orm/Entity/UserIpTable.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\UserIpTableRepository")

--- a/src/Orm/Entity/UserProfileVisitor.php
+++ b/src/Orm/Entity/UserProfileVisitor.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\JoinColumn;
 use Doctrine\ORM\Mapping\ManyToOne;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\UserProfileVisitorRepository")

--- a/src/Orm/Entity/Weapon.php
+++ b/src/Orm/Entity/Weapon.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\Table;
+use Doctrine\ORM\Mapping\Index;
 
 /**
  * @Entity(repositoryClass="Stu\Orm\Repository\WeaponRepository")


### PR DESCRIPTION
- Use the current supported way of creating an annotation based orm config
- Add missing Index and UniqueConstraint imports within the entities
