### PR TITLE
simplify enum method;

### DIFF
--- a/src/Component/Ship/ShipAlertStateEnum.php
+++ b/src/Component/Ship/ShipAlertStateEnum.php
@@ -10,16 +10,12 @@ enum ShipAlertStateEnum: int
     case ALERT_YELLOW = 2;
     case ALERT_RED = 3;
 
-    public static function getDescription(ShipAlertStateEnum $alertState): string
+    public function getDescription(): string
     {
-        switch ($alertState) {
-            case ShipAlertStateEnum::ALERT_GREEN:
-                return _("Alarm Grün");
-            case ShipAlertStateEnum::ALERT_YELLOW:
-                return _("Alarm Gelb");
-            case ShipAlertStateEnum::ALERT_RED:
-                return _("Alarm Rot");
-        }
-        return '';
+        return match ($this) {
+            self::ALERT_GREEN => _("Alarm Grün"),
+            self::ALERT_YELLOW => _("Alarm Gelb"),
+            self::ALERT_RED => _("Alarm Rot"),
+        };
     }
 }

--- a/src/Module/Tick/Ship/ShipTick.php
+++ b/src/Module/Tick/Ship/ShipTick.php
@@ -151,8 +151,8 @@ final class ShipTick implements ShipTickInterface
                 $ship->setAlertState(ShipAlertStateEnum::from($preState->value - $reduce));
                 $this->msg[] = sprintf(
                     _('Wechsel von %s auf %s wegen Energiemangel'),
-                    ShipAlertStateEnum::getDescription($preState),
-                    ShipAlertStateEnum::getDescription($ship->getAlertState())
+                    $preState->getDescription(),
+                    $ship->getAlertState()->getDescription()
                 );
             }
         }


### PR DESCRIPTION
Enums are objects, therefore this method doesn't need to be static.
[https://stitcher.io/blog/php-enums#enum-methods](https://stitcher.io/blog/php-enums#enum-methods)